### PR TITLE
Remove all event listeners

### DIFF
--- a/lib/gff.js
+++ b/lib/gff.js
@@ -52,6 +52,9 @@ gff.read = function (path) {
 
   rl.on('close', function () {
     gff.emit('end')
+    /* remove all event listener to prevent duplicate 
+    event listeners when reading parsing multiple GFF*/
+    gff.removeAllListeners()
   })
 
   return this

--- a/lib/gff.js
+++ b/lib/gff.js
@@ -52,8 +52,8 @@ gff.read = function (path) {
 
   rl.on('close', function () {
     gff.emit('end')
-    /* remove all event listener to prevent duplicate 
-    event listeners when reading parsing multiple GFF*/
+    /* remove all event listener to prevent duplicate
+    event listeners when parsing more than one GFF file */
     gff.removeAllListeners()
   })
 


### PR DESCRIPTION
All event listeners should be removed after finished parsing GFF, or it will create duplicate event listeners when reading multiple GFF